### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/utils/strings.py
+++ b/utils/strings.py
@@ -1,5 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+
 def filenamesplit(string):  # splits a full filename string into path, file, and extension.
     """Splits a full filename string into path, file, and extension; returns a tuple (path, file, extension,
     fileext).


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚