### PR TITLE
Set retry test workflow permissions

### DIFF
--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -2,6 +2,8 @@
 
 name: Test Retry Action
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:

--- a/plots.py
+++ b/plots.py
@@ -27,8 +27,8 @@ def plotresults(cam, im, P, S, B, bbox):
         y_range=(h, 0),
         plot_width=round(600 * w / h),
         plot_height=600,
-        x_axis_label=f"pixel (1 - {str(w)})",
-        y_axis_label=f"pixel (1 - {str(h)})",
+        x_axis_label=f"pixel (1 - {w!s})",
+        y_axis_label=f"pixel (1 - {h!s})",
         title=cam["filename"],
         tools="box_zoom,pan,save,reset,wheel_zoom",
         active_scroll="wheel_zoom",
@@ -57,7 +57,7 @@ def plotresults(cam, im, P, S, B, bbox):
                 P[0, :, i],
                 P[1, :, i],
                 color=colors[i],
-                legend=f"image {str(i)}",
+                legend=f"image {i!s}",
                 line_width=1,
             )
             a.circle(P[2, :, i], P[3, :, i], color=colors[i], size=10, alpha=0.6)
@@ -66,7 +66,7 @@ def plotresults(cam, im, P, S, B, bbox):
         a.circle(P[2].ravel(), P[3].ravel(), color=colors[1], legend="Reprojections", size=10, alpha=0.6)
 
     # Plot 2 - 3d
-    x, y, z = np.split(B[:, :3], 3, axis=1)
+    x, _y, z = np.split(B[:, :3], 3, axis=1)
     b = plotting.figure(
         plot_width=350,
         plot_height=300,
@@ -136,7 +136,7 @@ def bokeh_colors(n):
 
 
 def imshow(im, im2=None, p1=None, p2=None):
-    """Displays image `im` and optionally `im2` using Bokeh, supports RGB and Greyscale images, overlays points `p1`,
+    """Displays image `im` and optionally `im2` using Bokeh, supports RGB and Grayscale images, overlays points `p1`,
     `p2`.
     """
     io.reset_output()
@@ -157,8 +157,8 @@ def imshow(im, im2=None, p1=None, p2=None):
         y_range=(h, 0),
         plot_width=round(800 * w / h),
         plot_height=800,
-        x_axis_label=f"pixel (1 - {str(w)})",
-        y_axis_label=f"pixel (1 - {str(h)})",
+        x_axis_label=f"pixel (1 - {w!s})",
+        y_axis_label=f"pixel (1 - {h!s})",
         title="image",
         tools="box_zoom,pan,save,reset,wheel_zoom,crosshair",
         active_scroll="wheel_zoom",
@@ -202,8 +202,8 @@ def imshow(im, im2=None, p1=None, p2=None):
             y_range=(h, 0),
             plot_width=round(600 * w / h),
             plot_height=600,
-            x_axis_label=f"pixel (1 - {str(w)})",
-            y_axis_label=f"pixel (1 - {str(h)})",
+            x_axis_label=f"pixel (1 - {w!s})",
+            y_axis_label=f"pixel (1 - {h!s})",
             title="image",
             tools="box_zoom,pan,save,reset,wheel_zoom,crosshair",
             active_scroll="wheel_zoom",

--- a/utils/KLT.py
+++ b/utils/KLT.py
@@ -53,8 +53,7 @@ def cv2calcOpticalFlowPyrLK(im1, im2, p1, p2hat=None, fbt=None, **lk_param):
 
 # @profile
 def KLTregional(im0, im, p0, T, lk_param, fbt=1.0, translateFlag=False):
-    """Tracks regional keypoints using the Kanade-Lucas-Tomasi (KLT) algorithm with forward-backward error
-    thresholding.
+    """Tracks regional keypoints using the Kanade-Lucas-Tomasi (KLT) algorithm with forward-backward error thresholding.
     """
     T = T.astype(np.float32)
     # 1. Warp current image to past image frame
@@ -85,7 +84,7 @@ def KLTregional(im0, im, p0, T, lk_param, fbt=1.0, translateFlag=False):
 
     # convert p back to im coordinates
     if translateFlag:
-        p = pa + (xy0 + [dx, dy]).astype(np.float32)
+        p = pa + ([*xy0, dx, dy]).astype(np.float32)
     else:
         p = addcol1(pa + xy0) @ T
 

--- a/utils/NLS.py
+++ b/utils/NLS.py
@@ -7,10 +7,11 @@ from utils.transforms import *
 
 # @profile
 def estimateWorldCameraPose(K, p, p3, t=np.array([0, 0, 1]), R=np.eye(3), findR=False):
-    """
-    Estimates camera pose from world coordinates using non-linear least squares.
+    """Estimates camera pose from world coordinates using non-linear least squares.
 
-    Args: K (array): camera matrix, p (2D array): image points, p3 (3D array): world points, t (array, optional): initial translation, R (array, optional): initial rotation, findR (bool, optional): if True estimates rotation. Returns: tuple (translation, rotation, residuals, projected points).
+    Args: K (array): camera matrix, p (2D array): image points, p3 (3D array): world points, t (array, optional):
+    initial translation, R (array, optional): initial rotation, findR (bool, optional): if True estimates rotation.
+    Returns: tuple (translation, rotation, residuals, projected points).
     """
     # Linear solution
     # Re, te = extrinsicsPlanar(p, p3, K)
@@ -38,7 +39,7 @@ def extrinsicsPlanar(imagePoints, worldPoints, K):  # Copy of MATLAB function by
     # s[uv1]' = K * [R t] * [xyz1]'
 
     # Compute homography.
-    H, inliers = cv2.findHomography(worldPoints, imagePoints, method=0)  # methods = 0, RANSAC = 8, LMEDS, RHO
+    H, _inliers = cv2.findHomography(worldPoints, imagePoints, method=0)  # methods = 0, RANSAC = 8, LMEDS, RHO
     h1, h2, h3 = H[:, 0], H[:, 1], H[:, 2]
 
     A = K.T

--- a/utils/common.py
+++ b/utils/common.py
@@ -65,8 +65,7 @@ def world2image(K, R, t, pw):  # MATLAB worldToImage copy
 
 
 def elaz(x):  # cartesian coordinate to spherical el and az angles
-    """Converts Cartesian coordinates `x` to spherical elevation and azimuth angles; input shape can be (3,) or (N,
-    3).
+    """Converts Cartesian coordinates `x` to spherical elevation and azimuth angles; input shape can be (3,) or (N, 3).
     """
     s = x.shape
     r = norm(x)
@@ -149,8 +148,7 @@ def pscale(p3):  # normalizes camera coordinates so last column = 1
 
 
 def worldPointsLicensePlate(country="EU"):  # Returns x, y coordinates of license plate
-    """
-    Returns x, y coordinates of a standard license plate for given country; defaults to EU.
+    """Returns x, y coordinates of a standard license plate for given country; defaults to EU.
 
     Usage: `worldPointsLicensePlate(country='Chile')`.
     """

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -2,8 +2,7 @@
 
 
 def filenamesplit(string):  # splits a full filename string into path, file, and extension.
-    """Splits a full filename string into path, file, and extension; returns a tuple (path, file, extension,
-    fileext).
+    """Splits a full filename string into path, file, and extension; returns a tuple (path, file, extension, fileext).
     """
     i = string.rfind("/") + 1
     j = string.rfind(".")

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -65,8 +65,7 @@ def quat2dcm(q):  # 3 element quaternion representation (roll is norm(q))
 
 
 def dcm2quat(R):  # 3 element quaternion representation (roll is norm(q))
-    """
-    Converts direction cosine matrix `R` to quaternion; returns quaternion as [x, y, z, w].
+    """Converts direction cosine matrix `R` to quaternion; returns quaternion as [x, y, z, w].
 
     Expects `R` as a 3x3 matrix.
     """

--- a/vidExample.py
+++ b/vidExample.py
@@ -25,7 +25,7 @@ def vidExamplefcn():
     else:
         frames = np.arange(4122, 4134)  # 40km/h
         n = len(frames)
-        imagename = [f"{patha}IMG_{str(i)}.JPG" for i in frames]
+        imagename = [f"{patha}IMG_{i!s}.JPG" for i in frames]
         filename = imagename[0]
 
     cam, cap = getCameraParams(filename, platform="iPhone 6s")
@@ -155,7 +155,7 @@ def vidExamplefcn():
         msvFrame = 5
         if i == msvFrame:
             # B[0:i, 3:6], p3[vg] = fcnNLS_batch(K, P[:,:,0:i], p3, B[0:i, 3:6])
-            tmsv, p3hatmsv = fcnMSV1_t(K, P, B, vg, i)
+            _tmsv, p3hatmsv = fcnMSV1_t(K, P, B, vg, i)
             p3[vg] = p3hatmsv - t
             vp = vg  # enable all points now
 


### PR DESCRIPTION
## Summary
- add `permissions: {}` to the retry test workflow because it does not require `GITHUB_TOKEN` access

## CodeQL alerts
Addresses https://github.com/ultralytics/velocity/security/code-scanning/1

## Validation
- Parsed workflow YAML with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR mainly cleans up code style, improves documentation readability, and adds a safer default GitHub Actions permission setting, with no major feature or behavior changes.

### 📊 Key Changes
- 🔒 Added `permissions: {}` to the `test-retry` GitHub Actions workflow to disable default token permissions unless explicitly needed.
- ✨ Replaced several `str(...)` conversions inside f-strings with cleaner modern formatting like `{value!s}`.
- 📝 Improved docstring formatting and wording across multiple utility files for better readability and consistency.
- 🇺🇸 Standardized one spelling change from “Greyscale” to “Grayscale”.
- 🧽 Renamed a few unused variables to underscore-prefixed versions, such as `_y`, `_inliers`, and `_tmsv`, to make intent clearer and reduce lint warnings.
- 🛠️ Simplified one array construction in the KLT tracking utility without changing its apparent purpose.
- 📷 Applied small string-formatting cleanup in the video example script.

### 🎯 Purpose & Impact
- ✅ Makes the codebase easier to read, maintain, and review for contributors.
- 🔐 Improves CI security posture by following a least-privilege approach in GitHub Actions.
- 👀 Reduces noise from style and lint issues, helping developers focus on real problems.
- 📚 Makes inline documentation clearer for new users and maintainers working with the repository.
- 🚀 Likely little to no end-user impact in functionality, but it improves project quality and developer experience overall.