### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/utils/KLT.py
+++ b/utils/KLT.py
@@ -104,8 +104,8 @@ def KLTmain(im, im0, im0_small, p0):
     # Parameters for KLT
     EPS = cv2.TERM_CRITERIA_EPS
     COUNT = cv2.TERM_CRITERIA_COUNT
-    lk_coarse = dict(winSize=(15, 15), maxLevel=4, criteria=(EPS | COUNT, 10, 0.1))
-    lk_fine = dict(winSize=(51, 51), maxLevel=0, criteria=(EPS | COUNT, 30, 0.001))
+    lk_coarse = {"winSize": (15, 15), "maxLevel": 4, "criteria": (EPS | COUNT, 10, 0.1)}
+    lk_fine = {"winSize": (51, 51), "maxLevel": 0, "criteria": (EPS | COUNT, 30, 0.001)}
 
     # 1. Coarse tracking on 1/8 scale full image
     scale = 1 / 4

--- a/utils/MSV.py
+++ b/utils/MSV.py
@@ -1,6 +1,8 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from utils.common import *
+import numpy as np
+
+from utils.common import pixel2uvec, rms, uvec
 from utils.NLS import fzK
 
 
@@ -67,7 +69,7 @@ def fcnMSV2_t(K, P, B, vg, i):  # solves for 1 camera translation
     z = P[0:2, vg, i - 1 : i + 1].ravel("F")
     max_iter = 300
     mdm = np.eye(6) * 1  # marquardt damping matrix (eye times damping coefficient)
-    for i in range(max_iter):
+    for iteration in range(max_iter):
         a = fcnNvintercept(np.vstack((u0[:-2], -x.reshape((2, 3)))), U)
         a1 = a + x[:3]
         a2 = a + x[3:6]
@@ -83,12 +85,12 @@ def fcnMSV2_t(K, P, B, vg, i):  # solves for 1 camera translation
 
         JT = (JT - zhat) / dx
         JTJ = JT @ JT.T  # J.T @ J
-        delta = np.linalg.inv(JTJ + mdm) @ JT @ residual * min(((i + 1) * 0.01) ** 2, 1)
-        print(f"{i:g}: f={rms(z - zhat):g}, x={rms(delta)}")
+        delta = np.linalg.inv(JTJ + mdm) @ JT @ residual * min(((iteration + 1) * 0.01) ** 2, 1)
+        print(f"{iteration:g}: f={rms(z - zhat):g}, x={rms(delta)}")
         x = x + delta
         if rms(delta) < 1e-8:
             break
-    if i == (max_iter - 1):
+    if iteration == (max_iter - 1):
         print("WARNING: fcnMSV2_t() reaching max iterations!")
     # print('%i steps, residual rms = %.5f' % (i,rms(z-zhat)))
     return x.astype(np.float32)
@@ -268,26 +270,34 @@ def fcnMSV1direct_t(K, P, B, vg, i):  # solves for 1 camera translation
     max_iter = 2000
     xi = np.zeros((max_iter, 3))
     r = np.zeros((max_iter, 1))
-    for i in range(1, max_iter):
-        g, r[i] = grad_func(x, u0, U, K, Z)  # computes the gradient of the stochastic function
+    for iteration in range(1, max_iter):
+        g, r[iteration] = grad_func(x, u0, U, K, Z)  # computes the gradient of the stochastic function
         m = beta_1 * m + (1 - beta_1) * g  # updates the moving averages of the gradient
         v = beta_2 * v + (1 - beta_2) * (g * g)  # updates the moving averages of the squared gradient
-        m_cap = m / (1 - (beta_1**i))  # calculates the bias-corrected estimates
-        v_cap = v / (1 - (beta_2**i))  # calculates the bias-corrected estimates
+        m_cap = m / (1 - (beta_1**iteration))  # calculates the bias-corrected estimates
+        v_cap = v / (1 - (beta_2**iteration))  # calculates the bias-corrected estimates
         delta = (alpha * m_cap) / (v_cap**0.5 + epsilon)
         x = x - delta  # updates the parameters
-        print(f"Residual {r[i]:g},    Params: {x[:]}")
-        xi[i] = x
+        print(f"Residual {r[iteration]:g},    Params: {x[:]}")
+        xi[iteration] = x
         if rms(delta) < 1e-5:  # convergence check
             break
+
+    import plotly.graph_objs as go
+    import plotly.offline as py
 
     py.plot(
         [
             go.Scatter(
-                x=xi[:i, 0],
-                y=xi[:i, 2],
+                x=xi[:iteration, 0],
+                y=xi[:iteration, 2],
                 mode="markers",
-                marker=dict(size="16", color=(np.log10(r[:i]).ravel()), colorscale="Viridis", showscale=True),
+                marker={
+                    "size": "16",
+                    "color": (np.log10(r[:iteration]).ravel()),
+                    "colorscale": "Viridis",
+                    "showscale": True,
+                },
             )
         ]
     )

--- a/utils/NLS.py
+++ b/utils/NLS.py
@@ -2,11 +2,26 @@
 
 import time
 
-from utils.transforms import *
+import cv2
+import numpy as np
+
+from utils.common import (
+    addcol1,
+    cam2ned,
+    cc2sc,
+    norm,
+    pixel2uvec,
+    pscale,
+    rms,
+    sc2cc,
+    uvec,
+    world2image,
+)
+from utils.transforms import dcm2rpy, rpy2dcm
 
 
 # @profile
-def estimateWorldCameraPose(K, p, p3, t=np.array([0, 0, 1]), R=np.eye(3), findR=False):
+def estimateWorldCameraPose(K, p, p3, t=np.array([0, 0, 1]), R=np.eye(3), findR=False):  # noqa: B008
     """Estimates camera pose from world coordinates using non-linear least squares.
 
     Args: K (array): camera matrix, p (2D array): image points, p3 (3D array): world points, t (array, optional):
@@ -78,7 +93,7 @@ def fzK(a, K):
     return pscale(a @ K)
 
 
-def fzC(a, K, R, t=np.zeros((1, 3))):
+def fzC(a, K, R, t=np.zeros((1, 3))):  # noqa: B008
     """Applies perspective scaling to points `a` using camera matrix from `K`, `R`, and optionally `t`, returning scaled
     points.
     """

--- a/utils/images.py
+++ b/utils/images.py
@@ -1,9 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import cv2
+import math
 
-from utils.common import *
-from utils.strings import *
+import cv2
+import numpy as np
+
+from utils.strings import filenamesplit
 
 
 def boundingRect(x, imshape, border=(0, 0)):
@@ -31,8 +33,9 @@ def importEXIF(fullfilename):
     """Parses EXIF data from an image file specified by `fullfilename`, returning a dict with processed EXIF values."""
     import exifread
 
-    exif = exifread.process_file(open(fullfilename, "rb"), details=False)
-    for tag in exif.keys():
+    with open(fullfilename, "rb") as file:
+        exif = exifread.process_file(file, details=False)
+    for tag in exif:
         a = exif[tag].values[:]
         if type(a) is str and a.isnumeric():
             a = float(a)

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -12,5 +12,5 @@ def filenamesplit(string):
 
 def printd(dictionary):  # print dictionary
     """Print each key-value pair in a dictionary, with keys aligned for readability."""
-    for tag in dictionary.keys():
-        print("%40s: %s" % (tag, dictionary[tag]))
+    for tag in dictionary:
+        print(f"{tag:>40s}: {dictionary[tag]}")

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -13,4 +13,4 @@ def filenamesplit(string):
 def printd(dictionary):  # print dictionary
     """Print each key-value pair in a dictionary, with keys aligned for readability."""
     for tag in dictionary:
-        print(f"{tag:>40s}: {dictionary[tag]}")
+        print(f"{tag!s:>40}: {dictionary[tag]}")

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -1,6 +1,10 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from utils.common import *
+import math
+
+import numpy as np
+
+from utils.common import norm, sc2cc
 
 
 # @profile

--- a/vidExample.py
+++ b/vidExample.py
@@ -1,12 +1,23 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import time
+
+import cv2
+import numpy as np
 import scipy
 
 import plots
-from utils.images import *
-from utils.KLT import *
-from utils.MSV import *
-from utils.NLS import *
+from utils.common import addcol0, image2world, norm, worldPointsLicensePlate
+from utils.images import (
+    boundingRect,
+    fcnEXIF2LLAT,
+    getCameraParams,
+    importEXIF,
+    insidebbox,
+)
+from utils.KLT import KLTmain
+from utils.MSV import fcnMSV1_t
+from utils.NLS import estimateWorldCameraPose
 
 
 # @profile
@@ -128,7 +139,7 @@ def vidExamplefcn():
             P = np.empty([5, p.shape[0], n], dtype=np.float32)  # KLT [x y valid]
             P[:] = np.nan
 
-            imfirst, im0_small, dt, dr, r, t0 = im, None, np.nan, 0, 0, B[0, 12]
+            imfirst, im0, im0_small, dt, dr, r, t0 = im, im, None, np.nan, 0, 0, B[0, 12]
         else:
             # KLT
             p, v, im0_small = KLTmain(im, im0, im0_small, p)
@@ -144,7 +155,7 @@ def vidExamplefcn():
             r += dr
             B[i, 3:6] = t
             B[i, 0:3] = B[0, 0:3] + t
-            del im0
+            im0 = im
 
         # py.plot([go.Histogram(x=residuals, nbinsx=30)])
 


### PR DESCRIPTION
## Summary

Applies Ruff 0.16.0 with the latest Ultralytics Actions settings, replaces ambiguous wildcard imports with explicit owners, and fixes the undefined previous-frame state exposed by the new diagnostics.

## Validation

- Pinned Ruff 0.16.0 check and formatter pass with Python 3.8 target and BLE001/S110 ignores
- Python 3.8 syntax parsing passes
- `python -m compileall -q .`
- Focused imports and math/image utility smoke checks pass

Deleted: wildcard imports, shadowed loop variables, and the invalid deletion of previous-frame state.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactors the velocity utilities for cleaner imports, safer resource handling, and corrected iteration tracking without changing the core tracking workflow. 🛠️

### 📊 Key Changes
- Replaced wildcard imports with explicit imports across image, transformation, nonlinear least-squares, MSV, and video example modules.
- Renamed loop counters from `i` to `iteration` in optimization routines to avoid conflicts with function arguments and improve readability.
- Updated optimization logging, convergence checks, plotting ranges, and maximum-iteration warnings to use the new loop counter.
- Added explicit `numpy`, `math`, and OpenCV dependencies where needed.
- Improved Plotly marker configuration and dictionary formatting.
- Added a context manager when reading EXIF metadata files to ensure files are closed safely.
- Preserved the previous image frame correctly in `vidExample.py` by initializing and updating `im0`.

### 🎯 Purpose & Impact
- 🧹 Improves code clarity, maintainability, and compatibility with static analysis and linting tools.
- 🐞 Reduces the risk of loop-variable shadowing causing incorrect optimization behavior or diagnostics.
- 📈 Keeps optimization output and convergence plots aligned with the actual number of iterations.
- 🔒 Prevents EXIF file handles from remaining open after image metadata is read.
- 🎥 Makes the video tracking example more robust by ensuring KLT receives the correct previous frame.
- ⚙️ These are primarily internal quality and reliability improvements, with no intended change to the overall user-facing workflow.