### PR TITLE
Align README tail sections with Ultralytics standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ If this repository contributes to your research or project, please cite it using
 
 [![DOI](https://zenodo.org/badge/126519968.svg)](https://zenodo.org/badge/latestdoi/126519968)
 
-# 🤝 Contribute
+## 💡 Contribute
 
 We actively welcome contributions from the community! Whether it's fixing bugs, proposing new features, or enhancing documentation, your input is highly valued. Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) for more details on how to get started. We also encourage you to share your experiences with Ultralytics projects by completing our brief [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge 🙏 thank you to all our contributors!
 
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/velocity/graphs/contributors)
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
-# ©️ License
+## 📄 License
 
 Ultralytics provides two licensing options to accommodate different use cases:
 
 - **AGPL-3.0 License**: This [OSI-approved](https://opensource.org/license/agpl-v3) open-source license is ideal for students, researchers, and enthusiasts keen on open collaboration and knowledge sharing. It promotes transparency and community involvement. See the [LICENSE](https://github.com/ultralytics/velocity/blob/main/LICENSE) file for full details.
 - **Enterprise License**: Designed for commercial applications, this license permits the seamless integration of Ultralytics software and AI models into commercial products and services, bypassing the open-source requirements of AGPL-3.0. If your project requires commercial licensing, please contact us through [Ultralytics Licensing](https://www.ultralytics.com/license).
 
-# 📬 Contact Us
+## 📮 Contact
 
 For bug reports, feature suggestions, and contributions, please visit [GitHub Issues](https://github.com/ultralytics/velocity/issues). For broader questions and discussions about this project or other Ultralytics initiatives, join our vibrant community on [Discord](https://discord.com/invite/ultralytics)!
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project aims to leverage advanced [ML](https://www.ultralytics.com/glossary
 
 This repository includes a small `data/` example set, but not a standalone public [benchmark dataset](https://www.ultralytics.com/glossary/benchmark-dataset). The methods are designed for integration with custom datasets. If you possess relevant imagery or wish to collaborate on applying these techniques, please contact us. For general dataset needs, explore resources like [Roboflow](https://roboflow.com/?ref=ultralytics) or public datasets like [COCO](https://docs.ultralytics.com/datasets/detect/coco/).
 
-# 📋 Requirements
+## 📋 Requirements
 
 To execute the code within this repository, ensure you meet the following prerequisites:
 
@@ -48,13 +48,13 @@ To execute the code within this repository, ensure you meet the following prereq
   - `Statistics and Machine Learning Toolbox`
   - `Signal Processing Toolbox`
 
-# 🏃 Run
+## 🏃 Run
 
 This repository offers various methods for vehicle speed estimation using SFM and ML. While detailed run instructions are context-dependent, the core scripts leverage the libraries listed in the requirements. If you're interested in applying these techniques or need specific guidance on execution, please don't hesitate to reach out or raise an [Issue](https://github.com/ultralytics/velocity/issues).
 
 <img src="https://github.com/ultralytics/velocity/blob/main/results.jpg" alt="Sample speed estimation results visualization">
 
-# 📚 Citation
+## 📚 Citation
 
 If this repository contributes to your research or project, please cite it using the following DOI:
 


### PR DESCRIPTION
Second standardization pass: aligns the README with the canonical Ultralytics structure.

- Renamed the closing sections to the canonical headings: `## 💡 Contribute`, `## 📄 License`, `## 📮 Contact`.
- Demoted the remaining level-1 body sections to level 2, so the document is one `<h1>` title followed by `<h2>` sections instead of a flat run of `<h1>`s.
- The contributor image links `ultralytics/ultralytics` contributors now, which is the destination the canonical Ultralytics README uses for that badge and where the pictured contributor mosaic comes from.

Section prose, badges, banner, and all body content are unchanged. The `.github/` license headers and the LICENSE file were audited and already correct.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Improves the README structure and corrects the contributors link for clearer navigation and accurate community attribution.

### 📊 Key Changes
- Changed README section headings from level-one (`#`) to level-two (`##`) headings for better document hierarchy.
- Renamed the “Contribute” and “License” sections with updated emojis for improved consistency.
- Corrected the contributors image link to point to the main [Ultralytics repository contributors page](https://github.com/ultralytics/ultralytics/graphs/contributors).

### 🎯 Purpose & Impact
- ✅ Makes the README easier to read and better aligned with standard Markdown structure.
- 🧭 Improves navigation and organization for users reviewing the project documentation.
- 👥 Ensures the contributors badge directs users to the correct Ultralytics community contributor list.